### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/data_utils/file_utils.py
+++ b/data_utils/file_utils.py
@@ -112,7 +112,10 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(origin)
+        host = parsed_url.hostname
+        if host and (host == "modac.cancer.gov" or host.endswith(".modac.cancer.gov")):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot3-Pathology-Reports-Hierarchical-Self-Attention-Network/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot3-Pathology-Reports-Hierarchical-Self-Attention-Network/security/code-scanning/1)

To fix the issue, the code should parse the `origin` URL using `urllib.parse.urlparse` and validate its hostname. This ensures that the check is performed on the actual host of the URL, rather than relying on a substring match. Specifically, the hostname should either be `'modac.cancer.gov'` or end with `'.modac.cancer.gov'` to allow valid subdomains.

Changes to be made:
1. Import `urlparse` from `urllib.parse` if not already imported.
2. Replace the substring check (`'modac.cancer.gov' in origin`) with a hostname validation using `urlparse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
